### PR TITLE
feat(logger): add WithLogEnabled option to disable SQL logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The `NewDBTracer` function accepts various options to customize its behavior:
 
 #### Logging Options
 - `WithLogger(logger *slog.Logger)`: Sets a custom structured logger for query logging
+- `WithLogEnabled(enabled bool)`: Enables/disables logging
 - `WithShouldLog(shouldLog ShouldLog)`: Configures when to log based on error conditions
 - `WithLogArgs(enabled bool)`: Enables/disables logging of query arguments
 - `WithLogArgsLenLimit(limit int)`: Sets maximum length for logged arguments

--- a/dbtracer/dbtracer.go
+++ b/dbtracer/dbtracer.go
@@ -39,6 +39,7 @@ type dbTracer struct {
 	traceProvider    trace.TracerProvider
 	traceLibraryName string
 	includeQueryText bool
+	logEnabled       bool
 }
 
 func NewDBTracer(
@@ -69,6 +70,7 @@ func NewDBTracer(
 		},
 		logger:         slog.Default(),
 		includeSQLText: false,
+		logEnabled:     true,
 	}
 	for _, opt := range opts {
 		opt(&optCtx)
@@ -93,6 +95,7 @@ func NewDBTracer(
 		traceProvider:    optCtx.traceProvider,
 		traceLibraryName: optCtx.name,
 		includeQueryText: optCtx.includeSQLText,
+		logEnabled:       optCtx.logEnabled,
 	}, nil
 }
 

--- a/dbtracer/options.go
+++ b/dbtracer/options.go
@@ -23,6 +23,7 @@ type optionCtx struct {
 	logArgs         bool
 	logArgsLenLimit int
 	includeSQLText  bool
+	logEnabled      bool
 }
 
 type Option func(*optionCtx)
@@ -74,5 +75,11 @@ func WithLogArgsLenLimit(limit int) Option {
 func WithIncludeSQLText(includeSQLText bool) Option {
 	return func(oc *optionCtx) {
 		oc.includeSQLText = includeSQLText
+	}
+}
+
+func WithLogEnabled(enabled bool) Option {
+	return func(oc *optionCtx) {
+		oc.logEnabled = enabled
 	}
 }

--- a/dbtracer/traceconnect.go
+++ b/dbtracer/traceconnect.go
@@ -38,7 +38,7 @@ func (dt *dbTracer) TraceConnectEnd(ctx context.Context, data pgx.TraceConnectEn
 	if data.Err != nil {
 		dt.recordSpanError(connectData.span, data.Err)
 
-		if dt.shouldLog(data.Err) {
+		if dt.shouldLog(data.Err) && dt.logEnabled {
 			dt.logger.LogAttrs(ctx, slog.LevelError,
 				"database connect failed",
 				slog.String("host", connectData.connConfig.Host),
@@ -51,11 +51,13 @@ func (dt *dbTracer) TraceConnectEnd(ctx context.Context, data pgx.TraceConnectEn
 		return
 	}
 
-	dt.logger.LogAttrs(ctx, slog.LevelInfo,
-		"database connect",
-		slog.String("host", connectData.connConfig.Host),
-		slog.Uint64("port", uint64(connectData.connConfig.Port)),
-		slog.String("database", connectData.connConfig.Database),
-		slog.Duration("time", interval),
-	)
+	if dt.logEnabled {
+		dt.logger.LogAttrs(ctx, slog.LevelInfo,
+			"database connect",
+			slog.String("host", connectData.connConfig.Host),
+			slog.Uint64("port", uint64(connectData.connConfig.Port)),
+			slog.String("database", connectData.connConfig.Database),
+			slog.Duration("time", interval),
+		)
+	}
 }

--- a/dbtracer/tracecopyfrom.go
+++ b/dbtracer/tracecopyfrom.go
@@ -43,7 +43,7 @@ func (dt *dbTracer) TraceCopyFromEnd(ctx context.Context, conn *pgx.Conn, data p
 	if data.Err != nil {
 		dt.recordSpanError(copyFromData.span, data.Err)
 
-		if dt.shouldLog(data.Err) {
+		if dt.shouldLog(data.Err) && dt.logEnabled {
 			dt.logger.LogAttrs(ctx, slog.LevelError,
 				"copyfrom failed",
 				slog.Any("tableName", copyFromData.TableName),
@@ -55,13 +55,15 @@ func (dt *dbTracer) TraceCopyFromEnd(ctx context.Context, conn *pgx.Conn, data p
 		}
 	} else {
 		copyFromData.span.SetStatus(codes.Ok, "")
-		dt.logger.LogAttrs(ctx, slog.LevelInfo,
-			"copyfrom",
-			slog.Any("tableName", copyFromData.TableName),
-			slog.Any("columnNames", copyFromData.ColumnNames),
-			slog.Duration("time", interval),
-			slog.Uint64("pid", uint64(extractConnectionID(conn))),
-			slog.Int64("rowCount", data.CommandTag.RowsAffected()),
-		)
+		if dt.logEnabled {
+			dt.logger.LogAttrs(ctx, slog.LevelInfo,
+				"copyfrom",
+				slog.Any("tableName", copyFromData.TableName),
+				slog.Any("columnNames", copyFromData.ColumnNames),
+				slog.Duration("time", interval),
+				slog.Uint64("pid", uint64(extractConnectionID(conn))),
+				slog.Int64("rowCount", data.CommandTag.RowsAffected()),
+			)
+		}
 	}
 }

--- a/dbtracer/traceprepare.go
+++ b/dbtracer/traceprepare.go
@@ -63,7 +63,7 @@ func (dt *dbTracer) TracePrepareEnd(
 	if data.Err != nil {
 		dt.recordSpanError(prepareData.span, data.Err)
 
-		if dt.shouldLog(data.Err) {
+		if dt.shouldLog(data.Err) && dt.logEnabled {
 			dt.logger.LogAttrs(ctx, slog.LevelError,
 				"prepare failed",
 				slog.String("statement_name", prepareData.statementName),
@@ -75,13 +75,15 @@ func (dt *dbTracer) TracePrepareEnd(
 		}
 	} else {
 		prepareData.span.SetStatus(codes.Ok, "")
-		dt.logger.LogAttrs(ctx, slog.LevelInfo,
-			"prepare",
-			slog.String("statement_name", prepareData.statementName),
-			slog.String("sql", prepareData.sql),
-			slog.Duration("time", interval),
-			slog.Uint64("pid", uint64(extractConnectionID(conn))),
-			slog.Bool("alreadyPrepared", data.AlreadyPrepared),
-		)
+		if dt.logEnabled {
+			dt.logger.LogAttrs(ctx, slog.LevelInfo,
+				"prepare",
+				slog.String("statement_name", prepareData.statementName),
+				slog.String("sql", prepareData.sql),
+				slog.Duration("time", interval),
+				slog.Uint64("pid", uint64(extractConnectionID(conn))),
+				slog.Bool("alreadyPrepared", data.AlreadyPrepared),
+			)
+		}
 	}
 }


### PR DESCRIPTION
Allows users to completely disable SQL logging.

Changes:

- Added WithLogEnabled(bool) option to control logging behavior.
- Updated internal logging logic to respect the new flag.