### PR TITLE
Fix WithShouldLog behavior to execute ShouldLog function for all queries

### DIFF
--- a/dbtracer/dbtracer_test.go
+++ b/dbtracer/dbtracer_test.go
@@ -84,6 +84,10 @@ func (s *DBTracerSuite) SetupTest() {
 		Float64Histogram(mock.Anything, mock.Anything, mock.Anything).
 		Return(s.histogram, nil)
 
+	s.shouldLog.EXPECT().
+		Execute(mock.Anything).Maybe().
+		Return(true)
+
 	s.span.EXPECT().
 		SetAttributes(
 			semconv.DBSystemPostgreSQL,

--- a/dbtracer/tracebatch.go
+++ b/dbtracer/tracebatch.go
@@ -45,7 +45,7 @@ func (dt *dbTracer) TraceBatchQuery(ctx context.Context, conn *pgx.Conn, data pg
 		queryData.span.SetAttributes(semconv.DBQueryText(data.SQL))
 	}
 
-	logAttrs := []slog.Attr{}
+	var logAttrs []slog.Attr
 
 	if data.Err != nil {
 		queryData.span.SetStatus(codes.Error, data.Err.Error())
@@ -80,7 +80,7 @@ func (dt *dbTracer) TraceBatchEnd(ctx context.Context, conn *pgx.Conn, data pgx.
 
 	dt.recordHistogramMetric(ctx, "batch", queryData.queryName, interval, data.Err)
 
-	logAttrs := []slog.Attr{}
+	var logAttrs []slog.Attr
 
 	if data.Err != nil {
 		dt.recordSpanError(queryData.span, data.Err)

--- a/dbtracer/tracebatch.go
+++ b/dbtracer/tracebatch.go
@@ -45,27 +45,25 @@ func (dt *dbTracer) TraceBatchQuery(ctx context.Context, conn *pgx.Conn, data pg
 		queryData.span.SetAttributes(semconv.DBQueryText(data.SQL))
 	}
 
+	logAttrs := []slog.Attr{}
+
 	if data.Err != nil {
 		queryData.span.SetStatus(codes.Error, data.Err.Error())
 		queryData.span.RecordError(data.Err)
-
-		if dt.shouldLog(data.Err) {
-			dt.logger.LogAttrs(ctx, slog.LevelError,
-				queryName,
-				slog.String("sql", data.SQL),
-				slog.Any("args", dt.logQueryArgs(data.Args)),
-				slog.Uint64("pid", uint64(extractConnectionID(conn))),
-				slog.String("error", data.Err.Error()),
-			)
-		}
+		logAttrs = append(logAttrs, slog.String("error", data.Err.Error()))
 	} else {
 		queryData.span.SetStatus(codes.Ok, "")
-		dt.logger.LogAttrs(ctx, slog.LevelInfo,
-			queryName,
-			slog.String("sql", data.SQL),
+		logAttrs = append(logAttrs, slog.String("commandTag", data.CommandTag.String()))
+	}
+
+	if dt.shouldLog(data.Err) {
+		logAttrs = append(logAttrs, slog.String("sql", data.SQL),
 			slog.Any("args", dt.logQueryArgs(data.Args)),
 			slog.Uint64("pid", uint64(extractConnectionID(conn))),
-			slog.String("commandTag", data.CommandTag.String()),
+		)
+		dt.logger.LogAttrs(ctx, slog.LevelError,
+			queryName,
+			logAttrs...,
 		)
 	}
 }
@@ -82,23 +80,23 @@ func (dt *dbTracer) TraceBatchEnd(ctx context.Context, conn *pgx.Conn, data pgx.
 
 	dt.recordHistogramMetric(ctx, "batch", queryData.queryName, interval, data.Err)
 
+	logAttrs := []slog.Attr{}
+
 	if data.Err != nil {
 		dt.recordSpanError(queryData.span, data.Err)
-
-		if dt.shouldLog(data.Err) {
-			dt.logger.LogAttrs(ctx, slog.LevelError,
-				"batch queries",
-				slog.Duration("interval", interval),
-				slog.Uint64("pid", uint64(extractConnectionID(conn))),
-				slog.String("error", data.Err.Error()),
-			)
-		}
+		logAttrs = append(logAttrs, slog.String("error", data.Err.Error()))
 	} else {
+
 		queryData.span.SetStatus(codes.Ok, "")
-		dt.logger.LogAttrs(ctx, slog.LevelInfo,
-			"batch queries",
-			slog.Duration("interval", interval),
+	}
+
+	if dt.shouldLog(data.Err) {
+		logAttrs = append(logAttrs, slog.Duration("interval", interval),
 			slog.Uint64("pid", uint64(extractConnectionID(conn))),
+		)
+		dt.logger.LogAttrs(ctx, slog.LevelError,
+			"batch queries",
+			logAttrs...,
 		)
 	}
 }

--- a/dbtracer/traceconnect.go
+++ b/dbtracer/traceconnect.go
@@ -35,7 +35,7 @@ func (dt *dbTracer) TraceConnectEnd(ctx context.Context, data pgx.TraceConnectEn
 
 	defer connectData.span.End()
 
-	logAttrs := []slog.Attr{}
+	var logAttrs []slog.Attr
 
 	if data.Err != nil {
 		dt.recordSpanError(connectData.span, data.Err)

--- a/dbtracer/traceconnect.go
+++ b/dbtracer/traceconnect.go
@@ -35,27 +35,24 @@ func (dt *dbTracer) TraceConnectEnd(ctx context.Context, data pgx.TraceConnectEn
 
 	defer connectData.span.End()
 
+	logAttrs := []slog.Attr{}
+
 	if data.Err != nil {
 		dt.recordSpanError(connectData.span, data.Err)
-
-		if dt.shouldLog(data.Err) {
-			dt.logger.LogAttrs(ctx, slog.LevelError,
-				"database connect failed",
-				slog.String("host", connectData.connConfig.Host),
-				slog.Uint64("port", uint64(connectData.connConfig.Port)),
-				slog.String("database", connectData.connConfig.Database),
-				slog.Duration("time", interval),
-				slog.Any("error", data.Err),
-			)
-		}
-		return
+		logAttrs = append(logAttrs, slog.Any("error", data.Err))
 	}
 
-	dt.logger.LogAttrs(ctx, slog.LevelInfo,
-		"database connect",
-		slog.String("host", connectData.connConfig.Host),
-		slog.Uint64("port", uint64(connectData.connConfig.Port)),
-		slog.String("database", connectData.connConfig.Database),
-		slog.Duration("time", interval),
-	)
+	if dt.shouldLog(data.Err) {
+		logAttrs = append(logAttrs,
+			slog.String("host", connectData.connConfig.Host),
+			slog.Uint64("port", uint64(connectData.connConfig.Port)),
+			slog.String("database", connectData.connConfig.Database),
+			slog.Duration("time", interval),
+		)
+
+		dt.logger.LogAttrs(ctx, slog.LevelInfo,
+			"database connect",
+			logAttrs...,
+		)
+	}
 }

--- a/dbtracer/tracecopyfrom.go
+++ b/dbtracer/tracecopyfrom.go
@@ -40,28 +40,25 @@ func (dt *dbTracer) TraceCopyFromEnd(ctx context.Context, conn *pgx.Conn, data p
 	interval := endTime.Sub(copyFromData.startTime)
 	dt.recordHistogramMetric(ctx, "copy_from", "copy_from", interval, data.Err)
 
+	logAttrs := []slog.Attr{}
+
 	if data.Err != nil {
 		dt.recordSpanError(copyFromData.span, data.Err)
-
-		if dt.shouldLog(data.Err) {
-			dt.logger.LogAttrs(ctx, slog.LevelError,
-				"copyfrom failed",
-				slog.Any("tableName", copyFromData.TableName),
-				slog.Any("columnNames", copyFromData.ColumnNames),
-				slog.Duration("time", interval),
-				slog.Uint64("pid", uint64(extractConnectionID(conn))),
-				slog.String("error", data.Err.Error()),
-			)
-		}
+		logAttrs = append(logAttrs, slog.String("error", data.Err.Error()))
 	} else {
 		copyFromData.span.SetStatus(codes.Ok, "")
-		dt.logger.LogAttrs(ctx, slog.LevelInfo,
-			"copyfrom",
-			slog.Any("tableName", copyFromData.TableName),
+		logAttrs = append(logAttrs, slog.Int64("rowCount", data.CommandTag.RowsAffected()))
+	}
+
+	if dt.shouldLog(data.Err) {
+		logAttrs = append(logAttrs, slog.Any("tableName", copyFromData.TableName),
 			slog.Any("columnNames", copyFromData.ColumnNames),
 			slog.Duration("time", interval),
 			slog.Uint64("pid", uint64(extractConnectionID(conn))),
-			slog.Int64("rowCount", data.CommandTag.RowsAffected()),
+		)
+		dt.logger.LogAttrs(ctx, slog.LevelError,
+			"copyfrom failed",
+			logAttrs...,
 		)
 	}
 }

--- a/dbtracer/tracecopyfrom.go
+++ b/dbtracer/tracecopyfrom.go
@@ -40,7 +40,7 @@ func (dt *dbTracer) TraceCopyFromEnd(ctx context.Context, conn *pgx.Conn, data p
 	interval := endTime.Sub(copyFromData.startTime)
 	dt.recordHistogramMetric(ctx, "copy_from", "copy_from", interval, data.Err)
 
-	logAttrs := []slog.Attr{}
+	var logAttrs []slog.Attr
 
 	if data.Err != nil {
 		dt.recordSpanError(copyFromData.span, data.Err)

--- a/dbtracer/traceprepare.go
+++ b/dbtracer/traceprepare.go
@@ -60,28 +60,26 @@ func (dt *dbTracer) TracePrepareEnd(
 	interval := endTime.Sub(prepareData.startTime)
 	dt.recordHistogramMetric(ctx, "prepare", prepareData.queryName, interval, data.Err)
 
+	logAttrs := []slog.Attr{}
+
 	if data.Err != nil {
 		dt.recordSpanError(prepareData.span, data.Err)
-
-		if dt.shouldLog(data.Err) {
-			dt.logger.LogAttrs(ctx, slog.LevelError,
-				"prepare failed",
-				slog.String("statement_name", prepareData.statementName),
-				slog.String("sql", prepareData.sql),
-				slog.Duration("time", interval),
-				slog.Uint64("pid", uint64(extractConnectionID(conn))),
-				slog.String("error", data.Err.Error()),
-			)
-		}
+		logAttrs = append(logAttrs, slog.String("error", data.Err.Error()))
 	} else {
 		prepareData.span.SetStatus(codes.Ok, "")
-		dt.logger.LogAttrs(ctx, slog.LevelInfo,
-			"prepare",
-			slog.String("statement_name", prepareData.statementName),
+		logAttrs = append(logAttrs, slog.Bool("alreadyPrepared", data.AlreadyPrepared))
+
+	}
+
+	if dt.shouldLog(data.Err) {
+		logAttrs = append(logAttrs, slog.String("statement_name", prepareData.statementName),
 			slog.String("sql", prepareData.sql),
 			slog.Duration("time", interval),
 			slog.Uint64("pid", uint64(extractConnectionID(conn))),
-			slog.Bool("alreadyPrepared", data.AlreadyPrepared),
+		)
+		dt.logger.LogAttrs(ctx, slog.LevelError,
+			"prepare failed",
+			logAttrs...,
 		)
 	}
 }

--- a/dbtracer/traceprepare.go
+++ b/dbtracer/traceprepare.go
@@ -60,7 +60,7 @@ func (dt *dbTracer) TracePrepareEnd(
 	interval := endTime.Sub(prepareData.startTime)
 	dt.recordHistogramMetric(ctx, "prepare", prepareData.queryName, interval, data.Err)
 
-	logAttrs := []slog.Attr{}
+	var logAttrs []slog.Attr
 
 	if data.Err != nil {
 		dt.recordSpanError(prepareData.span, data.Err)

--- a/dbtracer/tracequery.go
+++ b/dbtracer/tracequery.go
@@ -58,32 +58,28 @@ func (dt *dbTracer) TraceQueryEnd(ctx context.Context, conn *pgx.Conn, data pgx.
 
 	defer queryData.span.End()
 
+	logAttrs := []slog.Attr{}
+
 	if data.Err != nil {
 		dt.recordSpanError(queryData.span, data.Err)
-
-		if dt.shouldLog(data.Err) {
-			dt.logger.LogAttrs(ctx, slog.LevelError,
-				fmt.Sprintf("Query failed: %s", queryData.queryName),
-				slog.String("sql", queryData.sql),
-				slog.String("query_name", queryData.queryName),
-				slog.Any("args", dt.logQueryArgs(queryData.args)),
-				slog.String("query_type", queryData.queryType),
-				slog.Duration("time", interval),
-				slog.Uint64("pid", uint64(extractConnectionID(conn))),
-				slog.String("error", data.Err.Error()),
-			)
-		}
+		logAttrs = append(logAttrs, slog.String("error", data.Err.Error()))
 	} else {
 		queryData.span.SetStatus(codes.Ok, "")
-		dt.logger.LogAttrs(ctx, slog.LevelInfo,
-			fmt.Sprintf("Query: %s", queryData.queryName),
-			slog.String("sql", queryData.sql),
+		logAttrs = append(logAttrs, slog.String("commandTag", data.CommandTag.String()))
+
+	}
+
+	if dt.shouldLog(data.Err) {
+		logAttrs = append(logAttrs, slog.String("sql", queryData.sql),
 			slog.String("query_name", queryData.queryName),
-			slog.String("query_type", queryData.queryType),
 			slog.Any("args", dt.logQueryArgs(queryData.args)),
+			slog.String("query_type", queryData.queryType),
 			slog.Duration("time", interval),
 			slog.Uint64("pid", uint64(extractConnectionID(conn))),
-			slog.String("commandTag", data.CommandTag.String()),
+		)
+		dt.logger.LogAttrs(ctx, slog.LevelError,
+			fmt.Sprintf("Query failed: %s", queryData.queryName),
+			logAttrs...,
 		)
 	}
 }

--- a/dbtracer/tracequery.go
+++ b/dbtracer/tracequery.go
@@ -58,7 +58,7 @@ func (dt *dbTracer) TraceQueryEnd(ctx context.Context, conn *pgx.Conn, data pgx.
 
 	defer queryData.span.End()
 
-	logAttrs := []slog.Attr{}
+	var logAttrs []slog.Attr
 
 	if data.Err != nil {
 		dt.recordSpanError(queryData.span, data.Err)


### PR DESCRIPTION
This PR fixes the WithShouldLog behavior to evaluate the ShouldLog function for all SQL queries, regardless of whether an error occurred. 

Changes:

- ShouldLog function is now called for every query, regardless of errors.
- ShouldLog function can now accept `nil` value as an argument, handling successful queries as well.
- Tests have been updated to match the new behavior.