### PR TITLE
Modified `shouldLog` to log only if the provided error is non-nil.

### DIFF
--- a/dbtracer/dbtracer.go
+++ b/dbtracer/dbtracer.go
@@ -51,8 +51,8 @@ func NewDBTracer(
 
 	optCtx := optionCtx{
 		name: "github.com/amirsalarsafaei/sqlc-pgx-monitoring",
-		shouldLog: func(_ error) bool {
-			return true
+		shouldLog: func(err error) bool {
+			return err != nil
 		},
 		meterProvider:   otel.GetMeterProvider(),
 		traceProvider:   otel.GetTracerProvider(),


### PR DESCRIPTION
shouldLog determines whether or not a log entry should be created based on the provided error. The updated implementation ensures that logging only occurs when `err` is not nil,  filtering out cases where there is no error to report.
